### PR TITLE
Add instructions for storing composer auth tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###
+
+###> composer auth token ###
+auth.json
+###< composer auth token ###

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ To install the node dependencies:
 docker-compose run --rm node npm install
 ```
 
+If you need to use an access token to fetch private dependencies from GitHub with Composer, copy the `auth.example.json` file contents to `auth.json` and add your token there. The `auth.json` file will not be tracked in git and will only be stored locally.
+
 ### Domain and Port Considerations
 
 The service architecture in this project ships with Apache to handle web traffic requests. By default it is set up to serve content on the `symfony-starter.test` domain. In order to access this site on your host machine you will need to update your hosts file:

--- a/auth.example.json
+++ b/auth.example.json
@@ -1,0 +1,5 @@
+{
+  "github-oauth": {
+    "github.com": "[TOKEN_GOES_HERE]"
+  }
+}


### PR DESCRIPTION
This PR updates the readme to indicate how to store a github access token for fetching private dependencies with composer. 

If you add an `auth.json` file to the project root with this content you should be good to go: 

```json
{
  "github-oauth": {
    "github.com": "[TOKEN_GOES_HERE]"
  }
}
```

This file will not be tracked by git and will only be kept locally.